### PR TITLE
Move capability into constant and make it configurable

### DIFF
--- a/includes/Admin/Ajax.php
+++ b/includes/Admin/Ajax.php
@@ -17,14 +17,14 @@ class Ajax {
     public function get_wildcard()
     {
         check_ajax_referer('simple301redirects', 'security');
-        if( ! current_user_can( 'manage_options' ) ) wp_die();
+        if( ! current_user_can( SIMPLE301REDIRECTS_CAPABILITY ) ) wp_die();
 		wp_send_json_success(get_option('301_redirects_wildcard'));
 		wp_die();
     }
     public function wildcard() 
     {
         check_ajax_referer('simple301redirects', 'security');
-        if( ! current_user_can( 'manage_options' ) ) wp_die();
+        if( ! current_user_can( SIMPLE301REDIRECTS_CAPABILITY ) ) wp_die();
         update_option('301_redirects_wildcard', sanitize_text_field($_POST['toggle']));
 		wp_send_json_success($_POST['toggle']);
 		wp_die();
@@ -32,7 +32,7 @@ class Ajax {
     public function install_plugin()
     {
         check_ajax_referer('simple301redirects', 'security');
-        if( ! current_user_can( 'manage_options' ) ) wp_die();
+        if( ! current_user_can( SIMPLE301REDIRECTS_CAPABILITY ) ) wp_die();
         $slug = isset($_POST['slug']) ? sanitize_text_field($_POST['slug']) : '';
         $result = \Simple301Redirects\Helper::install_plugin($slug);
         if (is_wp_error($result)) {
@@ -45,7 +45,7 @@ class Ajax {
     public function activate_plugin()
     {
         check_ajax_referer('simple301redirects', 'security');
-        if( ! current_user_can( 'manage_options' ) ) wp_die();
+        if( ! current_user_can( SIMPLE301REDIRECTS_CAPABILITY ) ) wp_die();
         $basename = isset($_POST['basename']) ? sanitize_text_field($_POST['basename']) : '';
         $result = activate_plugin($basename, '', false );
         if (is_wp_error($result)) {
@@ -60,7 +60,7 @@ class Ajax {
     public function hide_notice()
     {
         check_ajax_referer('simple301redirects', 'security');
-        if( ! current_user_can( 'manage_options' ) ) wp_die();
+        if( ! current_user_can( SIMPLE301REDIRECTS_CAPABILITY ) ) wp_die();
         $hide = isset($_POST['hide']) ? sanitize_text_field($_POST['hide']) : false;
         update_option('simple301redirects_hide_btl_notice', $hide);
         wp_send_json_success($hide);
@@ -70,7 +70,7 @@ class Ajax {
     public function fetch_all_links()
     {
         check_ajax_referer('simple301redirects', 'security');
-        if( ! current_user_can( 'manage_options' ) ) wp_die();
+        if( ! current_user_can( SIMPLE301REDIRECTS_CAPABILITY ) ) wp_die();
         wp_send_json_success(get_option('301_redirects'));
         wp_die();
     }
@@ -78,7 +78,7 @@ class Ajax {
     public function create_new_link()
     {
         check_ajax_referer('simple301redirects', 'security');
-        if( ! current_user_can( 'manage_options' ) ) wp_die();
+        if( ! current_user_can( SIMPLE301REDIRECTS_CAPABILITY ) ) wp_die();
         $key = (isset($_POST['key']) ? sanitize_text_field($_POST['key']) : '');
         $value = (isset($_POST['value']) ? sanitize_text_field($_POST['value']) : '');
         $links = get_option('301_redirects');
@@ -92,7 +92,7 @@ class Ajax {
     public function update_link()
     {
         check_ajax_referer('simple301redirects', 'security');
-        if( ! current_user_can( 'manage_options' ) ) wp_die();
+        if( ! current_user_can( SIMPLE301REDIRECTS_CAPABILITY ) ) wp_die();
         $key = (isset($_POST['key']) ? sanitize_text_field($_POST['key']) : '');
         $oldKey = (isset($_POST['oldKey']) ? sanitize_text_field($_POST['oldKey']) : '');
         $value = (isset($_POST['value']) ? sanitize_text_field($_POST['value']) : '');
@@ -111,7 +111,7 @@ class Ajax {
     public function delete_link()
     {
         check_ajax_referer('simple301redirects', 'security');
-        if( ! current_user_can( 'manage_options' ) ) wp_die();
+        if( ! current_user_can( SIMPLE301REDIRECTS_CAPABILITY ) ) wp_die();
         $key = (isset($_POST['key']) ? sanitize_text_field($_POST['key']) : '');
         $links = get_option('301_redirects');
 		if(isset($links[$key])){

--- a/includes/Admin/Menu.php
+++ b/includes/Admin/Menu.php
@@ -18,7 +18,7 @@ class Menu {
      * @return void
      */
     public function create_menu() {
-        add_options_page('301 Redirects', '301 Redirects', 'manage_options', '301options', array($this,'load_main_template'));
+        add_options_page('301 Redirects', '301 Redirects', SIMPLE301REDIRECTS_CAPABILITY, '301options', array($this,'load_main_template'));
     }
 
     public function load_main_template()

--- a/includes/Admin/Tools.php
+++ b/includes/Admin/Tools.php
@@ -13,7 +13,7 @@ class Tools
     {
         $page = isset($_GET['page']) ? $_GET['page'] : '';
         $export = isset($_REQUEST['export']) ? $_REQUEST['export'] : false;
-        if ($page === '301options' && $export == true && current_user_can('manage_options')) {
+        if ($page === '301options' && $export == true && current_user_can(SIMPLE301REDIRECTS_CAPABILITY)) {
             check_ajax_referer('simple301redirects', 'security');
             $content = get_option(SIMPLE301REDIRECTS_SETTINGS_NAME);
             $content = $this->prepare_csv_file_data(get_option(SIMPLE301REDIRECTS_SETTINGS_NAME));
@@ -45,7 +45,7 @@ class Tools
     {
         $page = isset($_GET['page']) ? $_GET['page'] : '';
         $import = isset($_REQUEST['import']) ? $_REQUEST['import'] : false;
-        if ($page === '301options' && $import == true && current_user_can('manage_options')) {
+        if ($page === '301options' && $import == true && current_user_can(SIMPLE301REDIRECTS_CAPABILITY)) {
             check_ajax_referer('simple301redirects', 'security');
             $file = $_FILES['upload_file'];
             if (!empty($file['tmp_name']) && 'csv' === pathinfo($file['name'])[ 'extension' ]) {

--- a/includes/Admin/WPDev/PluginUsageTracker.php
+++ b/includes/Admin/WPDev/PluginUsageTracker.php
@@ -594,7 +594,7 @@ class PluginUsageTracker {
         if( isset( $block_notice[$this->plugin_name] ) ) {
             return;
         }
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( SIMPLE301REDIRECTS_CAPABILITY ) ) {
             return;
         }
 

--- a/wp-simple-301-redirects.php
+++ b/wp-simple-301-redirects.php
@@ -75,6 +75,9 @@ if (!class_exists("Simple301redirects")) {
 			define('SIMPLE301REDIRECTS_ROOT_DIR_PATH', plugin_dir_path(__FILE__));
 			define('SIMPLE301REDIRECTS_ASSETS_DIR_PATH', SIMPLE301REDIRECTS_ROOT_DIR_PATH . 'assets/');
 			define('SIMPLE301REDIRECTS_ASSETS_URI', SIMPLE301REDIRECTS_PLUGIN_ROOT_URI . 'assets/');
+			if (!defined('SIMPLE301REDIRECTS_CAPABILITY')) {
+				define('SIMPLE301REDIRECTS_CAPABILITY', 'manage_options');
+			}
 		}
 
 		/**


### PR DESCRIPTION
I need the editor role to be able to edit the redirect setting on a project of mine. Currently, there is no way to change the necessary capability without it being overwritten with the next update. With my pull request, I added a constant for the capability which is set to `manage_options` by default. By setting

```php
define( 'SIMPLE301REDIRECTS_CAPABILITY', 'edit_pages' );
```

in your `wp-config.php` you can change the capability without changing the plugin code. There's no change in behavior for users that do not want to change the capability.